### PR TITLE
Add debian packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/
 dist/
 ospurge.egg-info/
 pbr-0.6-py2.7.egg/
+
+# Debian packaging is in branch "debian"
+debian


### PR DESCRIPTION
- Add "debian" to gitignore

:warning: Action to do:
Import my `debian` [branch](https://github.com/guilhem/ospurge/tree/debian)

Some packages will be done ASAP here: https://code.launchpad.net/~ospurge/+archive/ubuntu/daily
