### PR TITLE
Add support for cleaning up router interfaces on HA neutron routers

### DIFF
--- a/ospurge/resources/neutron.py
+++ b/ospurge/resources/neutron.py
@@ -44,10 +44,24 @@ class RouterInterfaces(base.ServiceResource):
         )
 
     def list(self):
-        return self.cloud.list_ports(
-            filters={'device_owner': 'network:router_interface',
-                     'tenant_id': self.cleanup_project_id}
-        )
+        router_interfaces = self.cloud.list_ports(filters={
+            'tenant_id': self.cleanup_project_id,
+            'device_owner': 'network:router_interface'})
+
+        dist_router_interfaces = self.cloud.list_ports(filters={
+            'tenant_id': self.cleanup_project_id,
+            'device_owner': 'network:router_interface_distributed'})
+
+        ha_router_interfaces = self.cloud.list_ports(filters={
+            'tenant_id': self.cleanup_project_id,
+            'device_owner': 'network:ha_router_replicated_interface'})
+
+        router_gateways = self.cloud.list_ports(filters={
+            'tenant_id': self.cleanup_project_id,
+            'device_owner': 'network:router_gateway'})
+
+        return (router_interfaces + dist_router_interfaces +
+                ha_router_interfaces + router_gateways)
 
     def delete(self, resource):
         self.cloud.remove_router_interface({'id': resource['device_id']},

--- a/ospurge/tests/resources/test_neutron.py
+++ b/ospurge/tests/resources/test_neutron.py
@@ -76,12 +76,28 @@ class TestRouterInterfaces(unittest.TestCase):
         )
 
     def test_list(self):
-        self.assertIs(self.cloud.list_ports.return_value,
-                      neutron.RouterInterfaces(self.creds_manager).list())
-        self.cloud.list_ports.assert_called_once_with(
-            filters={'device_owner': 'network:router_interface',
-                     'tenant_id': self.creds_manager.project_id}
-        )
+        self.cloud.list_ports.return_value = []
+
+        self.assertIsInstance(
+            neutron.RouterInterfaces(self.creds_manager).list(), list)
+
+        self.cloud.list_ports.assert_has_calls([
+            mock.call(filters={
+                'device_owner': 'network:router_interface',
+                'tenant_id': self.creds_manager.project_id}),
+
+            mock.call(filters={
+                'device_owner': 'network:router_interface_distributed',
+                'tenant_id': self.creds_manager.project_id}),
+
+            mock.call(filters={
+                'device_owner': 'network:ha_router_replicated_interface',
+                'tenant_id': self.creds_manager.project_id}),
+
+            mock.call(filters={
+                'device_owner': 'network:router_gateway',
+                'tenant_id': self.creds_manager.project_id}),
+        ])
 
     def test_delete(self):
         iface = mock.MagicMock()


### PR DESCRIPTION
For Openstack deployments with DVR/HA, there are additional router
interfaces which must be deleted befor the router can be deleted.

A similar fix was submitted to Openstack shade:
https://github.com/openstack-infra/shade/commit/e4fb68662753546f29ab054754d13bc94b661525